### PR TITLE
Remove GLib dependency

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,11 +9,14 @@ LDFLAGS ?=
 LDFLAGS += @BUILD_MODE_LDFLAGS@
 
 # -- Sources and targets ---
-OPENMP_SRC := mats.c backtrack.c minimalf.c uniqueg.c orientedg.c
+COMMON_SRC := mats.c backtrack.c orientedf.c orientedg.c upperg.c upperf.c canonicalg.c uniqueg.c spinf.c spincf.c orbitg.c minimalf.c
+
+OPENMP_SRC := $(COMMON_SRC)
+OPENMP_SRC += $(wildcard test-*.c)
 OPENMP_APP := $(patsubst %.c, %, $(OPENMP_SRC))
 OPENMP_OBJ := tlsbuf.o
 
-NAUTY_SRC := mats.c backtrack.c orientedf.c orientedg.c upperg.c upperf.c canonicalg.c uniqueg.c spinf.c spincf.c orbitg.c minimalf.c
+NAUTY_SRC := $(COMMON_SRC)
 NAUTY_SRC += $(wildcard test-*.c)
 NAUTY_APP := $(patsubst %.c, %, $(NAUTY_SRC))
 NAUTY_OBJ := dag.o bucket.o
@@ -23,7 +26,9 @@ OBJ  := bott.o common.o
 LIB  := gap.so
 LOBJ := $(patsubst %.o, %.lo, $(OBJ))
 
-TARGETS := $(APP) $(LIB)
+TARGETS := $(APP)
+
+# TARGETS += $(LIB)
 
 # --- list of object files for application targets ---
 APP_OBJ := $(APP:%=%.o)
@@ -44,11 +49,11 @@ $(OPENMP_APP): LDFLAGS += @OPENMP_CFLAGS@
 $(OPENMP_APP): OBJ     += $(OPENMP_OBJ)
 
 # The following rules configure the build for the $(NAUTY_APP) target:
-# - CFLAGS are extended with compiler flags for Nauty, GLib, and XXHash libraries.
-# - LDFLAGS are extended with runtime path and linker flags for Nauty, GLib, and XXHash libraries.
+# - CFLAGS are extended with compiler flags for Nauty and XXHash libraries.
+# - LDFLAGS are extended with runtime path and linker flags for Nauty and XXHash libraries.
 # - OBJ specifies the object files required to build $(NAUTY_APP).
-$(NAUTY_APP): CFLAGS  += @NAUTY_CFLAGS@ @GLIB_CFLAGS@ @XXHASH_CFLAGS@
-$(NAUTY_APP): LDFLAGS += @RPATH@ @NAUTY_LIBS@ @GLIB_LIBS@ @XXHASH_LIBS@
+$(NAUTY_APP): CFLAGS  += @NAUTY_CFLAGS@ @XXHASH_CFLAGS@
+$(NAUTY_APP): LDFLAGS += @RPATH@ @NAUTY_LIBS@ @XXHASH_LIBS@
 $(NAUTY_APP): OBJ     += $(NAUTY_OBJ)
 
 # The following rule appends additional compiler flags (@APP_CFLAGS@) to all application targets in $(APP).
@@ -87,7 +92,7 @@ $(APP): %: %.o $$(OBJ)
 	$(GAC) -o $@ $< -c -p "$(CFLAGS)"
 
 # Add Nauty and GLib flags for building the shared library
-%.so: CFLAGS += @NAUTY_CFLAGS@ @GLIB_CFLAGS@
+%.so: CFLAGS += @NAUTY_CFLAGS@
 # Build the shared library (.so) from .c source and .lo objects using GAC
 %.so: %.c $(LOBJ)
 	$(GAC) -d $< -o $@ -p "$(CFLAGS)" -L "$(LOBJ) $(LDFLAGS)"
@@ -121,7 +126,7 @@ distclean: clean
 	@rm -f $(wildcard test.d6)
 
 # -- make test.d6 file - the default for testing apps --
-test-data:
+test.d6:
 	@geng 4 | directg -a >  test.d6
 	@geng 5 | directg -a >> test.d6
 	@geng 6 | directg -a >> test.d6
@@ -130,3 +135,6 @@ test-data:
 	@geng 9  9:11 | directg -a >> test.d6
 	@geng 10 9:11 | directg -a >> test.d6
 	@geng 11 9:11 | directg -a >> test.d6
+
+test: test.d6 testall.sh $(APP)
+	@./testall.sh

--- a/bott.c
+++ b/bott.c
@@ -1,6 +1,6 @@
-#include "common.h"
-#include "bott.h"
 #include <assert.h>
+
+#include "bott.h"
 
 void populate_cache(vec_t **cache, size_t *size, const int dim)
 {
@@ -27,7 +27,6 @@ void populate_cache(vec_t **cache, size_t *size, const int dim)
 vec_t *init(const ind_t dim)
 {
     vec_t *mat = (vec_t*)calloc(dim, sizeof(vec_t));
-    // memset(mat, 0, sizeof(vec_t) * dim);
     return mat;
 }
 
@@ -37,7 +36,7 @@ void print_mat(const vec_t *mat, const ind_t dim)
 
     for (ind_t i=0; i<dim; i++) {
         for (ind_t j=0; j<dim; j++) {
-            printf("%c", c[C(mat[i],dim,j)]);
+            printf("%c", c[C(mat[i],j)]);
         }
         printf("\n");
     }
@@ -65,7 +64,7 @@ bool is_spinc(const vec_t *mat, const ind_t dim)
             if (z && aij) {
                 z = 0;
             }
-            if (e && aij!=C(mat[i],dim,j)) {
+            if (e && aij!=C(mat[i],j)) {
                 e = 0;
             }
             if (e==0 && z==0) {
@@ -85,7 +84,7 @@ bool is_spin(const vec_t *mat, const ind_t dim)
         int rem = row_sum(mat[j]) % 4;
         if (rem == 2) {
             for (ind_t i=0; i<j; i++) {
-                if (scalar_product(mat[i], mat[j]) != C(mat[i],dim,j)) {
+                if (scalar_product(mat[i], mat[j]) != C(mat[i],j)) {
                     return false;
                 }
             }
@@ -100,14 +99,12 @@ bool is_spin(const vec_t *mat, const ind_t dim)
     return true;
 }
 
-
 /*
  * isomorphism operations for Bott matrices
  * based on:
  * "Real Bott manifolds and acyclic digraphs" by Suyoung Choi, Mikiya Masuda, Sang-il Oum
  * https://arxiv.org/abs/1104.0072
  */
-
 
 /* Op1 */
 void swap_rows_and_cols(vec_t *src, vec_t *dst, ind_t dim, ind_t r1, ind_t r2)
@@ -156,170 +153,4 @@ int matrix_weight(const vec_t *mat, const ind_t dim)
         w += row_sum(mat[i]);
     }
     return w;
-}
-
-//************************************************************************************************
-/* this is to delete, since we will use d6 format from dag.c file */
-
-const vec_t row_masks[]      = { 0, 1, 3, 7, 15, 31, 63, 127, 255, 511, 1023, 2047, 4095 };
-const ind_t row_characters[] = { 0, 1, 1, 1,  1,  2,  2,   2,   2,   3,    3,    3,    3 };
-const ind_t mat_characters[] = { 0, 1, 2, 3,  4, 10, 12,  14,  16,  27,   30,   33,   36 };
-
-void encode_matrix(const vec_t *mat, const ind_t dim, char *buffer)
-{
-    for (ind_t i=0; i<dim; i++) {
-        snprintf(buffer+i*row_characters[dim], row_characters[dim]+1, "%0*lx", row_characters[dim], mat[i]&row_masks[dim]);
-    }
-}
-
-char* matrix_to_digraph6(const vec_t *mat, int dim) {
-    // This function encodes a Bott matrix into a digraph6 string.
-
-    // Ensure the output buffer is large enough
-    // for the maximum size of dim (which is 12).
-    // The maximum size is 1 (header) + 24 (body) + 1 (null terminator) = 26.
-    // So a buffer of size 100 is more than sufficient.
-    static char digraph_string[100];
-
-    // We assume dim >= 0 and dim < 12, so no need for extensive checks.
-    if (dim == 0) {
-        digraph_string[0] = '@'; // ASCII 64, for n=0
-        digraph_string[1] = '\0';
-        return digraph_string;
-    }
-
-    // Number of bits in the adjacency matrix
-    int num_bits = dim * dim;
-    // Number of 6-bit chunks needed for the body
-    int num_bytes_body = (num_bits + 5) / 6;
-    int total_length = 1 + 1 + num_bytes_body + 1; // '&' + 1 for header, 1 for null terminator
-
-    // Step 1: Encode the number of vertices (dim). Since dim <= 12,
-    // for GAP digraphs start with '&' (ASCII 38).
-    digraph_string[0] = '&'; // ASCII 38, for n <= 62
-    // Next character encodes the number of vertices.
-    digraph_string[1] = dim + 63;
-
-    // Step 2: Encode the bit stream from the matrix directly into the string
-    int bit_count = 0;
-    int output_index = 2; // Start after '&' and header
-    unsigned char current_byte = 0;
-
-    for (int i = 0; i < dim; i++) {
-        for (int j = 0; j < dim; j++) {
-            // Get the current bit
-            int bit = C(mat[i], dim, j);
-
-            // Pack the bit into the current 6-bit chunk
-            current_byte |= (bit << (5 - (bit_count % 6)));
-            bit_count++;
-
-            // If a 6-bit chunk is complete, add it to the string
-            if (bit_count % 6 == 0) {
-                digraph_string[output_index] = current_byte + 63;
-                output_index++;
-                current_byte = 0;
-            }
-        }
-    }
-
-    // Pad the last chunk with zeros if it's not full and add to the string
-    if (bit_count % 6 != 0) {
-        digraph_string[output_index] = current_byte + 63;
-        output_index++;
-    }
-
-    digraph_string[total_length - 1] = '\0';
-    return digraph_string;
-}
-
-/**
- * @brief Decodes a single character from the digraph6 format.
- *
- * This helper function converts a character from the base-64 digraph6 alphabet
- * back to its 6-bit integer value.
- *
- * @param c The character to decode.
- * @return The 6-bit value.
- */
-static inline unsigned char d6_char_to_int(char c) {
-    if (c >= '?' && c <= '~') {
-        return c - '?';
-    } else if (c >= '!' && c <= '`') {
-        return c - '!';
-    }
-    return 0; // Should not happen with valid digraph6 strings
-}
-
-/**
- * @brief Converts a digraph6 string into an adjacency matrix.
- *
- * This function manually parses a digraph6 string and populates a pre-allocated
- * matrix with the adjacency information. The matrix is represented as an array
- * of vec_t, where each vec_t corresponds to a row of the adjacency matrix.
- *
- * @param digraph6_str The input digraph6 string.
- * @param matrix A pre-allocated array of vec_t to store the adjacency matrix.
- * It must be of size n.
- * @param n The number of vertices in the graph.
- * @return 0 on success, -1 on failure (e.g., if the string is too short).
- */
-int digraph6_to_matrix(const char *digraph6_str, vec_t *matrix, int n) {
-    if (n >= 63) {
-        // We can't use uint64_t for rows if n > 64, so we return an error.
-        return -1;
-    }
-
-    // Initialize the matrix with zeros
-    memset(matrix, 0, n * sizeof(vec_t));
-
-    // Determine the start of the data stream, skipping the header.
-    // The d6 format is variable-length for the number of vertices.
-    const char *data_ptr = digraph6_str + 2;
-
-
-    // This is the corrected logic. We use a bit index to track our position
-    // in the bitstream and iterate through each character of the d6 string.
-    int current_bit = 5;
-    unsigned char current_char_value = d6_char_to_int(*data_ptr);
-    
-    for (int i = 0; i < n; i++) {
-        for (int j = 0; j < n; j++) {
-            // if (i == j) {
-            //     continue; // Skip the diagonal
-            // }
-            
-            int bit = (current_char_value >> current_bit) & 1;
-            
-            if (bit) {
-                matrix[i] |= (1ULL << j);
-            }
-            
-            current_bit--;
-            if (current_bit < 0) {
-                data_ptr++;
-                current_char_value = d6_char_to_int(*data_ptr);
-                current_bit = 5;
-            }
-        }
-    }
-
-    return 0;
-}
-
-void decode_matrix(vec_t *mat, const ind_t dim, const char *buffer)
-{
-    if (dim == 0) {
-        return;
-    }
-
-    const size_t row_chars = row_characters[dim];
-    char temp_buffer[row_chars + 1];
-
-    for (ind_t i = 0; i < dim; i++) {
-        memcpy(temp_buffer, buffer + i * row_chars, row_chars);
-        temp_buffer[row_chars] = '\0';
-
-        mat[i] = strtol(temp_buffer, NULL, 16);
-    }
 }

--- a/bott.h
+++ b/bott.h
@@ -1,11 +1,8 @@
-#ifndef BOTT_H
-#define BOTT_H
+#pragma once
 
 #include "common.h"
 
-#include <stdlib.h>
 #include <stdbool.h>
-#include <stdint.h>
 
 /* ensure we are in 64-bit environment */
 #include <bits/wordsize.h>
@@ -16,13 +13,6 @@
 #ifndef SWAP
     #define SWAP(T, a, b) do { T SWAP_TMP = a; a = b; b = SWAP_TMP; } while (0)
 #endif
-
-#define C(row,dim,j) ((row>>(j))&1)
-
-
-typedef uint8_t  ind_t;
-typedef uint64_t state_t;
-typedef uint64_t vec_t;
 
 static INLINE int scalar_product(vec_t a, vec_t b)
 {
@@ -55,7 +45,7 @@ static INLINE void matrix_by_state(vec_t *mat, const vec_t *cache, const state_t
     }
 }
 
-static inline bool is_upper_triangular(const vec_t *mat, const ind_t dim)
+static INLINE bool is_upper_triangular(const vec_t *mat, const ind_t dim)
 {
     vec_t row_mask = 1;
     for (ind_t i=1; i<dim; ++i) {
@@ -70,13 +60,9 @@ static inline bool is_upper_triangular(const vec_t *mat, const ind_t dim)
 /* main workers of this app */
 bool is_spinc(const vec_t *mat, const ind_t dim);
 
-static inline int row_sum(vec_t r)
+static INLINE int row_sum(vec_t r)
 {
-#if VEC_T_SIZE == 64
     return __builtin_popcountl(r);
-#else
-    return __builtin_popcount(r);
-#endif
 }
 
 static INLINE bool is_orientable(const vec_t *mat, const ind_t dim)
@@ -100,17 +86,3 @@ void conditional_add_col(const vec_t *src, vec_t *dst, ind_t dim, ind_t k);
 bool conditional_add_row(const vec_t *src, vec_t *dst, ind_t dim, ind_t l, ind_t m);
 
 int matrix_weight(const vec_t *mat, const ind_t dim);
-
-/* to delete - not needed anymore */
-
-extern const ind_t mat_characters[];
-
-void encode_matrix(const vec_t *mat, const ind_t dim, char *buffer);
-
-void decode_matrix(vec_t *mat, const ind_t dim, const char *buffer);
-
-char* matrix_to_digraph6(const vec_t *mat, int dim);
-
-int digraph6_to_matrix(const char *digraph6_str, vec_t *matrix, int n);
-
-#endif /* BOTT_H */

--- a/bucket.c
+++ b/bucket.c
@@ -1,14 +1,16 @@
 #include "common.h"
 
+#include <omp.h>
+
 #if NAUTY_HAS_TLS
 
-#   define G_MUTEX_LOCK(x)   g_mutex_lock(x)
-#   define G_MUTEX_UNLOCK(x) g_mutex_unlock(x)
+#   define MUTEX_LOCK(x)   omp_set_lock(x)
+#   define MUTEX_UNLOCK(x) omp_unset_lock(x)
 
 #else
 
-#   define G_MUTEX_LOCK(x)
-#   define G_MUTEX_UNLOCK(x)
+#   define MUTEX_LOCK(x)
+#   define MUTEX_UNLOCK(x)
 
 #endif
 
@@ -26,26 +28,24 @@
 #define MAX_OCCUPIED 0.80
 #endif
 
-typedef enum { BUCKET_GLIB = 0, BUCKET_FLAT128 = 1 } BucketKind;
-
 #define CTRL_EMPTY   ((uint8_t)0)
 #define CTRL_FULL    ((uint8_t)1)
 #define CTRL_DELETED ((uint8_t)2)
 
-static inline uint64_t hash16(const key128_t *k)
+static INLINE uint64_t hash16(const key128_t *k)
 {
     return XXH3_64bits(k->b, 16);
 }
 
 static size_t next_pow2(size_t x) {
-    // Zachowaj oryginalne zachowanie dla małych wartości.
+    // Keep the original behavior for small values.
     if (x <= 8) return 8;
     x--;
 #if SIZE_MAX > 0xFFFFFFFFu
-    // System 64-bitowy: używamy __builtin_clzl (dla unsigned long)
+    // 64-bit system: use __builtin_clzl (for unsigned long)
     return (size_t)1 << (64 - __builtin_clzl(x));
 #else
-    // System 32-bitowy: używamy __builtin_clz (dla unsigned int)
+    // 32-bit system: use __builtin_clz (for unsigned int)
     return (size_t)1 << (32 - __builtin_clz(x));
 #endif
 }
@@ -54,30 +54,30 @@ void flat_init(FlatSet *s, size_t cap_hint) {
     s->cap  = next_pow2(cap_hint ? cap_hint : 1024);
     s->size = 0;
     s->dels = 0;
-    s->keys = (key128_t*)g_malloc_n(s->cap, sizeof(key128_t));
-    s->ctrl = (uint8_t*)g_malloc0_n(s->cap, sizeof(uint8_t));
+    s->keys = (key128_t*)calloc(s->cap, sizeof(key128_t));
+    s->ctrl = (uint8_t*) calloc(s->cap, sizeof(uint8_t) );
 }
 
 void flat_free(FlatSet *s) {
     if (!s){
         return;
     }
-    g_free(s->keys);
-    g_free(s->ctrl);
-    s->keys = NULL; 
+    free(s->keys);
+    free(s->ctrl);
+    s->keys = NULL;
     s->ctrl = NULL;
     s->cap = s->size = s->dels = 0;
 }
 
 static void flat_rehash(FlatSet *s, size_t new_cap) {
     FlatSet dst;
-    dst.cap = 0; 
-    dst.size = dst.dels = 0; 
-    dst.keys = NULL; 
+    dst.cap = 0;
+    dst.size = dst.dels = 0;
+    dst.keys = NULL;
     dst.ctrl = NULL;
     flat_init(&dst, new_cap);
 
-    for (size_t i = 0; i < s->cap; ++i) { 
+    for (size_t i = 0; i < s->cap; ++i) {
         if (s->ctrl[i] == CTRL_FULL) {
             key128_t k = s->keys[i];
             uint64_t h = hash16(&k);
@@ -91,21 +91,20 @@ static void flat_rehash(FlatSet *s, size_t new_cap) {
             dst.size++;
         }
     }
-    g_free(s->keys); 
-    g_free(s->ctrl);
+    free(s->keys);
+    free(s->ctrl);
     *s = dst;
 }
 
 bool flat_lookup(const FlatSet *s, const key128_t *k) {
-    if (s->cap == 0) return FALSE;
+    if (s->cap == 0) return false;
     uint64_t h = hash16(k);
     size_t m = s->cap - 1, i = (size_t)(h & m);
     for (;;) {
         uint8_t c = s->ctrl[i];
         if (c == CTRL_EMPTY) {
-            return FALSE;
+            return false;
         }
-        // if (c == CTRL_FULL && memcmp(&s->keys[i], k, K_LEN) == 0){
         if (c == CTRL_FULL && key128_equal(&s->keys[i], k)){
             return TRUE;
         }
@@ -114,15 +113,15 @@ bool flat_lookup(const FlatSet *s, const key128_t *k) {
 }
 
 
-static inline double flat_load(const FlatSet *s) {
+static INLINE double flat_load(const FlatSet *s) {
     return (double)(s->size + s->dels) / (double)s->cap;
 }
 
 // --- New: separate real (true) load and occupied load (FULL + DELETED)
-static inline double true_load(const FlatSet *s) {
+static INLINE double true_load(const FlatSet *s) {
     return s->cap ? (double)s->size / (double)s->cap : 0.0;
 }
-static inline double occupied_load(const FlatSet *s) {
+static INLINE double occupied_load(const FlatSet *s) {
     return s->cap ? (double)(s->size + s->dels) / (double)s->cap : 0.0;
 }
 
@@ -130,21 +129,19 @@ static inline double occupied_load(const FlatSet *s) {
 // Shrink only when true load is clearly low, to avoid ping-pong.
 static void flat_maybe_shrink(FlatSet *s)
 {
-    // const double MIN_TRUE = 0.20;  // poniżej tego próbujemy zmniejszać
-    // const double MAX_TRUE = 0.80;  // po zmniejszeniu chcemy <= 80%
     const size_t MIN_CAP  = 16;
 
     if (s->cap > MIN_CAP && true_load(s) < MIN_TRUE) {
         size_t target = (size_t)((double)s->size / MAX_TRUE) + 1;
         if (target < MIN_CAP) target = MIN_CAP;
         if (target < s->cap) {
-            flat_rehash(s, target); // wyrówna do najbliższej potęgi 2
+            flat_rehash(s, target); // aligns to next_pow2
         }
     }
 }
 
 bool flat_remove(FlatSet *s, const key128_t *k) {
-    if (s->cap == 0) return FALSE;
+    if (s->cap == 0) return false;
 
     uint64_t h = hash16(k);
     size_t m = s->cap - 1;
@@ -153,9 +150,8 @@ bool flat_remove(FlatSet *s, const key128_t *k) {
     for (;;) {
         uint8_t c = s->ctrl[i];
         if (c == CTRL_EMPTY){
-            return FALSE;
+            return false;
         }
-        // if (c == CTRL_FULL && memcmp(&s->keys[i], k, K_LEN) == 0) {
         if (c == CTRL_FULL && key128_equal(&s->keys[i], k)) {
             s->ctrl[i] = CTRL_DELETED;
             s->size--;
@@ -163,7 +159,7 @@ bool flat_remove(FlatSet *s, const key128_t *k) {
             if (s->dels > s->size && s->dels > s->cap / 8) {
                 flat_rehash(s, s->cap);
             } else {
-                // ewentualny shrink z histerezą (lekki, rzadko zadziała)
+                // possible shrink with hysteresis (only if true load is low)
                 flat_maybe_shrink(s);
             }
 
@@ -178,12 +174,12 @@ bool flat_insert(FlatSet *s, const key128_t *k) {
 
     if (occupied_load(s) > MAX_OCCUPIED) {
         if (true_load(s) <= MAX_TRUE) {
-            // dużo grobów -> kompaktuj zamiast rosnąć
+            // lots of tombstones -> compact
             flat_rehash(s, s->cap);
         } else {
-            // faktycznie za ciasno -> zwiększ do rozmiaru dającego MAX_TRUE
+            // tight -> grow
             size_t need = (size_t)((double)(s->size + 1) / MAX_TRUE) + 1;
-            flat_rehash(s, need);  // next_pow2 wykona pośrednie zaokrąglenie
+            flat_rehash(s, need);  // next_pow2 will get the right size
         }
     }
 
@@ -206,9 +202,8 @@ bool flat_insert(FlatSet *s, const key128_t *k) {
                 first_del = i;
             }
         } else {
-            // if (memcmp(&s->keys[i], k, K_LEN) == 0) {
             if (key128_equal(&s->keys[i], k)) {
-                return FALSE;
+                return false;
             }
         }
         i = (i + 1) & m;
@@ -231,93 +226,39 @@ static void flat_reserve(FlatSet *s, size_t n_expected, double max_true) {
     }
 }
 
-/* ---- Hybrid bucket with shard locks ---- */
+/* ---- Bucket with shard locks ---- */
 struct _GHashBucket {
-    BucketKind  kind;
-    gsize       nshards;
-    ATOMIC_ATTR gsize number_of_elements;
+    size_t      nshards;
+    ATOMIC_ATTR size_t number_of_elements;
 
     /* Locks: one per shard (used in both modes). */
-    GMutex    *locks;
+    omp_lock_t    *locks;
 
-    /* GLIB mode */
-    GHashTable **tables;
-    GDestroyNotify key_destroy_func;
-    GDestroyNotify value_destroy_func;
-    GHashFunc      shard_hash_func;
+    /* release the elements */
+    destroy_func_t key_destroy_func;
 
-    /* FLAT128 mode */
     FlatSet   *flat;
 };
 
-static inline size_t shard_index_glib(const GHashBucket *b, gconstpointer key) {
-    GHashFunc hf = b->shard_hash_func ? b->shard_hash_func : g_direct_hash;
-    return hf(key) % b->nshards;
-}
-static inline size_t shard_index_flat(const GHashBucket *b, const key128_t *k) {
+static INLINE size_t shard_index_flat(const GHashBucket *b, const key128_t *k) {
     return (size_t)(hash16(k) % (uint64_t)b->nshards);
 }
-static inline size_t shard_index_flat_h(const GHashBucket *b, uint64_t h) {
+static INLINE size_t shard_index_flat_h(const GHashBucket *b, uint64_t h) {
     return (size_t)(h % (uint64_t)b->nshards);
 }
 
-// GHashBucket* g_bucket_new_full(
-//     GHashFunc      hash_func,
-//     GEqualFunc     key_equal_func,
-//     GDestroyNotify key_destroy_func,
-//     GDestroyNotify value_destroy_func,
-//     gsize          shards)
-// {
-//     GHashBucket *bucket = (GHashBucket*)g_malloc0(sizeof(GHashBucket));
-//     bucket->nshards = shards ? shards : 1;
-//     bucket->number_of_elements = 0;
-//     bucket->key_destroy_func = key_destroy_func;
-//     bucket->value_destroy_func = value_destroy_func;
-//     bucket->locks = (GMutex*)g_malloc0_n(bucket->nshards, sizeof(GMutex));
-//     for (gsize i = 0; i < bucket->nshards; ++i) g_mutex_init(&bucket->locks[i]);
-
-//     gboolean is_key128 = (hash_func == key128_hash) && (key_equal_func == key128_equal);
-
-//     if (is_key128) {
-//         bucket->kind = BUCKET_FLAT128;
-//         bucket->flat = (FlatSet*)g_malloc0_n(bucket->nshards, sizeof(FlatSet));
-//         bucket->tables = NULL;
-//         bucket->shard_hash_func = NULL;
-//     } else {
-// #ifdef __USE_GLIB
-//         bucket->kind = BUCKET_GLIB;
-//         bucket->tables = (GHashTable**)g_malloc_n(bucket->nshards, sizeof(GHashTable*));
-//         for (gsize i = 0; i < bucket->nshards; ++i) {
-//             bucket->tables[i] = g_hash_table_new_full(hash_func, key_equal_func,
-//                                                       key_destroy_func, value_destroy_func);
-//         }
-//         bucket->flat = NULL;
-//         bucket->shard_hash_func = hash_func;
-// #else
-//         fprintf(stderr, "wrong parameters for bucket, quitting ...\n");
-//         exit(1);
-// #endif
-//     }
-//     return bucket;
-// }
-
 GHashBucket* g_bucket_new_128(
-    GDestroyNotify key_destroy_func,
-    GDestroyNotify value_destroy_func,
-    gsize          shards)
+    destroy_func_t key_destroy_func,
+    size_t         shards)
 {
-    GHashBucket *bucket = (GHashBucket*)g_malloc0(sizeof(GHashBucket));
+    GHashBucket *bucket = (GHashBucket*)malloc(sizeof(GHashBucket));
     bucket->nshards = shards ? shards : 1;
     bucket->number_of_elements = 0;
     bucket->key_destroy_func = key_destroy_func;
-    bucket->value_destroy_func = value_destroy_func;
-    bucket->locks = (GMutex*)g_malloc0_n(bucket->nshards, sizeof(GMutex));
-    for (gsize i = 0; i < bucket->nshards; ++i) g_mutex_init(&bucket->locks[i]);
+    bucket->locks = (omp_lock_t*)calloc(bucket->nshards, sizeof(omp_lock_t));
+    for (size_t i = 0; i < bucket->nshards; ++i) omp_init_lock(&bucket->locks[i]);
 
-    bucket->kind = BUCKET_FLAT128;
-    bucket->flat = (FlatSet*)g_malloc0_n(bucket->nshards, sizeof(FlatSet));
-    bucket->tables = NULL;
-    bucket->shard_hash_func = NULL;
+    bucket->flat = (FlatSet*)calloc(bucket->nshards, sizeof(FlatSet));
 
     return bucket;
 }
@@ -325,163 +266,102 @@ GHashBucket* g_bucket_new_128(
 void g_bucket_destroy(GHashBucket *b)
 {
     if (!b) return;
-#ifdef __USE_GLIB
-    if (b->kind == BUCKET_GLIB) {
-        for (gsize i = 0; i < b->nshards; ++i) g_hash_table_destroy(b->tables[i]);
-        g_free(b->tables);
-    } else
-#endif
-    {
-        for (gsize i = 0; i < b->nshards; ++i) flat_free(&b->flat[i]);
-        g_free(b->flat);
-    }
-    for (gsize i = 0; i < b->nshards; ++i) g_mutex_clear(&b->locks[i]);
-    g_free(b->locks);
-    g_free(b);
+    for (size_t i = 0; i < b->nshards; ++i) flat_free(&b->flat[i]);
+    free(b->flat);
+    for (size_t i = 0; i < b->nshards; ++i) omp_destroy_lock(&b->locks[i]);
+    free(b->locks);
+    free(b);
 }
 
-gsize g_bucket_size(GHashBucket *b) {
+size_t g_bucket_size(GHashBucket *b) {
     return b ? ATOMIC_GET(b->number_of_elements) : 0;
 }
 
-gpointer g_bucket_lookup(GHashBucket* b, const key128_t* k)
+void *g_bucket_lookup(GHashBucket* b, const key128_t* k)
 {
     if (!b) return NULL;
-#ifdef __USE_GLIB
-    if (b->kind == BUCKET_GLIB) {
-        size_t idx = shard_index_glib(b, key);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        gpointer v = g_hash_table_lookup(b->tables[idx], key);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        return v;
-    } else
-#endif
-    {
-        // const key128_t *k = (const key128_t*)key;
-        size_t idx = shard_index_flat(b, k);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        gboolean ok = flat_lookup(&b->flat[idx], k);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        return ok ? GINT_TO_POINTER(TRUE) : NULL;
-    }
+    size_t idx = shard_index_flat(b, k);
+    MUTEX_LOCK(&b->locks[idx]);
+    bool ok = flat_lookup(&b->flat[idx], k);
+    MUTEX_UNLOCK(&b->locks[idx]);
+    return ok ? GINT_TO_POINTER(TRUE) : NULL;
 }
 
-gboolean g_bucket_remove(GHashBucket* b, const key128_t* k)
+bool g_bucket_remove(GHashBucket* b, const key128_t* k)
 {
-    if (!b) return FALSE;
-    gboolean res = FALSE;
-#ifdef __USE_GLIB
-    if (b->kind == BUCKET_GLIB) {
-        size_t idx = shard_index_glib(b, key);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        if (g_hash_table_remove(b->tables[idx], key)) { b->number_of_elements--; res = TRUE; }
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-    } else
-#endif
-    {
-        // const key128_t *k = (const key128_t*)key;
-        size_t idx = shard_index_flat(b, k);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        res = flat_remove(&b->flat[idx], k);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        if (res) {
-            ATOMIC_DEC(b->number_of_elements);
-        }
+    if (!b) return false;
+    bool res = false;
+
+    size_t idx = shard_index_flat(b, k);
+    MUTEX_LOCK(&b->locks[idx]);
+    res = flat_remove(&b->flat[idx], k);
+    MUTEX_UNLOCK(&b->locks[idx]);
+    if (res) {
+        ATOMIC_DEC(b->number_of_elements);
     }
+
     return res;
 }
 
-gboolean g_bucket_insert(GHashBucket *b, const key128_t* kptr, gpointer value)
+bool g_bucket_insert(GHashBucket *b, const key128_t* kptr, void *value)
 {
-    (void)value; if (!b) return FALSE;
- #ifdef __USE_GLIB   
-    if (b->kind == BUCKET_GLIB) {
-        size_t idx = shard_index_glib(b, key);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        gboolean ins = g_hash_table_insert(b->tables[idx], key, GINT_TO_POINTER(TRUE));
-        if (ins) b->number_of_elements++;
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        return ins;
-    } else
-#endif
-    {
-        // key128_t *kptr = (key128_t*)key;
-        size_t idx = shard_index_flat(b, kptr);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        //if (b->flat[idx].cap == 0) flat_init(&b->flat[idx], 1024);
-        gboolean ins = flat_insert(&b->flat[idx], kptr);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        /* We copied bytes; respect caller ownership per contract. */
-        // if (b->key_destroy_func) b->key_destroy_func(key);
-        if (ins) {
-            ATOMIC_INC(b->number_of_elements);
-        }
-        return ins;
+    (void)value; if (!b) return false;
+
+    size_t idx = shard_index_flat(b, kptr);
+    MUTEX_LOCK(&b->locks[idx]);
+
+    bool ins = flat_insert(&b->flat[idx], kptr);
+    MUTEX_UNLOCK(&b->locks[idx]);
+    /* We copied bytes; respect caller ownership per contract. */
+
+    if (ins) {
+        ATOMIC_INC(b->number_of_elements);
     }
+    return ins;
 }
 
-gboolean g_bucket_insert_copy128(GHashBucket *b, const key128_t *key)
+bool g_bucket_insert_copy128(GHashBucket *b, const key128_t *key)
 {
-    if (!b) return FALSE;
-#ifdef __USE_GLIB
-    if (b->kind == BUCKET_GLIB) {
-        key128_t *dup = (key128_t*)g_memdup2(key, sizeof(key128_t));
-        size_t idx = shard_index_glib(b, dup);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        gboolean ins = g_hash_table_insert(b->tables[idx], dup, GINT_TO_POINTER(TRUE));
-        if (ins) b->number_of_elements++;
-        else g_free(dup);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        return ins;
-    } else
-#endif
-    {
-        size_t idx = shard_index_flat(b, key);
-        G_MUTEX_LOCK(&b->locks[idx]);
-        if (b->flat[idx].cap == 0) flat_init(&b->flat[idx], 1024);
-        gboolean ins = flat_insert(&b->flat[idx], key);
-        G_MUTEX_UNLOCK(&b->locks[idx]);
-        if (ins) ATOMIC_INC(b->number_of_elements);
-        return ins;
-    }
+    if (!b) return false;
+
+    size_t idx = shard_index_flat(b, key);
+    MUTEX_LOCK(&b->locks[idx]);
+    if (b->flat[idx].cap == 0) flat_init(&b->flat[idx], 1024);
+    bool ins = flat_insert(&b->flat[idx], key);
+    MUTEX_UNLOCK(&b->locks[idx]);
+    if (ins) ATOMIC_INC(b->number_of_elements);
+    return ins;
 }
 
-void g_bucket_foreach128(GHashBucket *b, GKey128ForeachFunc func, gpointer user_data)
+void g_bucket_foreach128(GHashBucket *b, GKey128ForeachFunc func, void *user_data)
 {
     if (!b || !func) return;
-#ifdef __USE_GLIB
-    if (b->kind != BUCKET_FLAT128) {
-        /* Optional: warn; for GLIB we could iterate and cast keys if they are key128_t*,
-         * but local sets in our use are always FLAT128. */
-        return;
-    }
-#endif
-    for (gsize s = 0; s < b->nshards; ++s) {
-        G_MUTEX_LOCK(&b->locks[s]);
+
+    for (size_t s = 0; s < b->nshards; ++s) {
+        MUTEX_LOCK(&b->locks[s]);
         FlatSet *fs = &b->flat[s];
         for (size_t i = 0; i < fs->cap; ++i) {
             if (fs->ctrl[i] == CTRL_FULL) func(&fs->keys[i], user_data);
         }
-        G_MUTEX_UNLOCK(&b->locks[s]);
+        MUTEX_UNLOCK(&b->locks[s]);
     }
 }
 
-gboolean g_bucket_is_flat128(GHashBucket* b) { return b && b->kind == BUCKET_FLAT128; }
+bool g_bucket_is_flat128(GHashBucket* b) { return b!=NULL; }
 
 // --- New: reserve total capacity across shards.
 // NOTE: call this before concurrent use. No locking inside.
 void g_bucket_reserve(GHashBucket *b, uint64_t total_expected)
 {
-    if (!b || b->kind != BUCKET_FLAT128 || total_expected == 0) return;
+    if (!b || total_expected == 0) return;
 
-    // const double MAX_TRUE = 0.80; // docelowy load po rezerwacji
-    const double SKEW     = 1.15; // zapas na nierówną dystrybucję; dostosuj w razie potrzeby
+    const double SKEW     = 1.15;
 
-    // Prosty podział przez liczbę shardów + zapas na skew
+    // Simple per-shard expected count with skew factor
     double base = (double) total_expected / (double) b->nshards;
     size_t per_shard_expected = (size_t)(base * SKEW);
 
-    for (gsize i = 0; i < b->nshards; ++i) {
+    for (size_t i = 0; i < b->nshards; ++i) {
         flat_reserve(&b->flat[i], per_shard_expected, MAX_TRUE);
     }
 }

--- a/bucket.h
+++ b/bucket.h
@@ -1,30 +1,12 @@
-#ifndef BUCKET_H
-#define BUCKET_H
+#pragma once
 
-#include <glib.h>
+#define GINT_TO_POINTER(x) ((void*)(int)(x))
+
 #include <stdbool.h>
 #include <math.h>
 #include <xxhash.h>
 
-#if HASH_MIXED_MODE == 1
-#   define __USE_GLIB
-#else
-#   undef __USE_GLIB
-#endif
-
-#include "d6pack11.h"
-/* ---- 16-byte key type for compact exact IDs (canonical d6 zero-padded) ---- */
-#ifndef K_LEN
-#   define K_LEN 16
-#endif
-#ifndef D6PACK_KEY128_T_DEFINED
-typedef union { 
-    unsigned char b[K_LEN];
-#if defined(__SIZEOF_INT128__)
-    __uint128_t   u;
-#endif
-} key128_t;
-#endif
+#include "common.h"
 
 /* ---- Internal flat open-addressing set for 16/32-byte keys ---- */
 typedef struct {
@@ -34,6 +16,7 @@ typedef struct {
     size_t    size;   /* # FULL slots */
     size_t    dels;   /* # tombstones */
 } FlatSet;
+
 void flat_init(FlatSet *s, size_t cap_hint);
 void flat_free(FlatSet *s);
 bool flat_lookup(const FlatSet *s, const key128_t *k);
@@ -42,7 +25,6 @@ bool flat_insert(FlatSet *s, const key128_t *k);
 
 /* Opaque bucket type with two backends:
  *  - FLAT128 (open addressing; compact) when used with key128_hash/key128_equal
- *  - GLIB (GHashTable shards) otherwise
  */
 typedef struct _GHashBucket GHashBucket;
 
@@ -51,23 +33,15 @@ typedef struct _GHashBucket GHashBucket;
  * the bucket uses FLAT128 (compact) per shard; otherwise GLib tables.
  *
  * key_destroy_func:
- *  - GLIB mode: stored and used by GHashTable to free keys on remove/destroy.
  *  - FLAT128 mode: used only by g_bucket_insert (pointer variant) to free caller key
  *    immediately after copying bytes internally (so callers may pass malloc'd keys).
- * value_destroy_func: only used in GLIB mode (we do not store values in FLAT128).
  */
-// GHashBucket* g_bucket_new_full(
-//     GHashFunc      hash_func,
-//     GEqualFunc     key_equal_func,
-//     GDestroyNotify key_destroy_func,
-//     GDestroyNotify value_destroy_func,
-//     gsize          shards
-// );
+
+typedef void (*destroy_func_t)(void *pointer);
 
 GHashBucket* g_bucket_new_128(
-    GDestroyNotify key_destroy_func,
-    GDestroyNotify value_destroy_func,
-    gsize          shards
+    destroy_func_t key_destroy_func,
+    size_t         shards
 );
 
 /* Destroy the whole bucket and free internal storage. */
@@ -75,49 +49,47 @@ void    g_bucket_destroy (GHashBucket *b);
 
 /* Insert (pointer API). Returns TRUE iff inserted (key was not present).
  * In FLAT128 mode, the key bytes are copied; if key_destroy_func != NULL the
- * caller pointer is freed immediately. In GLIB mode the key pointer becomes
- * owned by the table (freed via key_destroy_func on removal/destroy).
+ * caller pointer is freed immediately.
  */
-gboolean g_bucket_insert (GHashBucket *b, const key128_t* key, gpointer value);
+bool g_bucket_insert (GHashBucket *b, const key128_t* key, void *value);
 
 /* By-value insert for 16-byte keys (recommended for performance & no allocs).
  * Works in both modes:
  *  - FLAT128: copies bytes inline (no allocations).
- *  - GLIB: duplicates a 16-byte heap key and inserts with (value == TRUE).
  */
-gboolean g_bucket_insert_copy128 (GHashBucket *b, const key128_t *key);
+bool g_bucket_insert_copy128 (GHashBucket *b, const key128_t *key);
 
 /* Remove key (match by value). Returns TRUE iff the key was present and removed. */
-gboolean g_bucket_remove (GHashBucket *b, const key128_t* key);
+bool g_bucket_remove (GHashBucket *b, const key128_t* key);
 
 /* Lookup key. Returns non-NULL iff present (compatible with previous usage). */
-gpointer g_bucket_lookup (GHashBucket *b, const key128_t* key);
+void *g_bucket_lookup (GHashBucket *b, const key128_t* key);
 
 /* Number of elements (sum over shards). */
-gsize    g_bucket_size   (GHashBucket *b);
+size_t    g_bucket_size   (GHashBucket *b);
 
 /* Iterate all keys (16-byte) — only meaningful for FLAT128 mode.
  * 'func' is called with the address of each inline key.
  * Safe under concurrent use because we lock shards internally for iteration.
  */
-typedef void (*GKey128ForeachFunc)(const key128_t *key, gpointer user_data);
-void     g_bucket_foreach128 (GHashBucket *b, GKey128ForeachFunc func, gpointer user_data);
+typedef void (*GKey128ForeachFunc)(const key128_t *key, void *user_data);
+void     g_bucket_foreach128 (GHashBucket *b, GKey128ForeachFunc func, void *user_data);
 
 /* Hash & equal for 16-byte keys. */
-static inline guint key128_hash(const unsigned char *p) {
-    return (guint)XXH3_64bits(p, 16);
+static INLINE unsigned int key128_hash(const unsigned char *p) {
+    return (unsigned int)XXH3_64bits(p, 16);
 }
 
-static inline gboolean key128_equal(const key128_t* a, const key128_t* b) {
-#if defined(__SIZEOF_INT128__)
+static INLINE bool key128_equal(const key128_t* a, const key128_t* b) {
+#if HAVE_UINT128
     return a->u == b->u;
 #else
     return memcmp(a, b, 16) == 0;
 #endif
 }
 
-static inline gboolean key128_lt(const key128_t* a, const key128_t* b) {
-#if defined(__SIZEOF_INT128__)
+static INLINE bool key128_lt(const key128_t* a, const key128_t* b) {
+#if HAVE_UINT128
     return a->u < b->u;
 #else
     return memcmp(a, b, 16) < 0;
@@ -125,11 +97,11 @@ static inline gboolean key128_lt(const key128_t* a, const key128_t* b) {
 }
 
 /* Mode probe (optional; handy for assertions in debugging). */
-gboolean g_bucket_is_flat128 (GHashBucket *b);
+bool g_bucket_is_flat128 (GHashBucket *b);
 
 void g_bucket_reserve(GHashBucket *b, uint64_t total_expected);
 
-static inline size_t shards_for_cap_limit(uint64_t total_expected,
+static INLINE size_t shards_for_cap_limit(uint64_t total_expected,
                      double   skew,        // np. 1.15
                      double   max_true,    // np. 0.80
                      unsigned cap_limit_pow2)
@@ -142,5 +114,3 @@ static inline size_t shards_for_cap_limit(uint64_t total_expected,
     size_t shards = (size_t)ceil(need);
     return shards>127 ? shards : 823;
 }
-
-#endif /* BUCKET_H */

--- a/canonicalg.c
+++ b/canonicalg.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "dag.h"
 
 /*
@@ -11,7 +10,7 @@ int main(void) {
     int n;
     char line[MAXLINE]; // Buffer for reading input lines
     char d6[MAXLINE];
-    
+
     if (fgets(line, sizeof(line), stdin) == NULL) {
         return 0;
     }

--- a/common.h
+++ b/common.h
@@ -1,9 +1,8 @@
-#ifndef COMMON_H
-#define COMMON_H
+#pragma once
 
 #define _GNU_SOURCE
 #include <time.h>
-#include <stdio.h>
+#include <stdarg.h>
 #include <stdint.h>
 
 #include "config.h"
@@ -28,10 +27,30 @@
 #ifndef HAVE_UINT128
 #   if defined(__SIZEOF_INT128__)
 #       define HAVE_UINT128 1
+        typedef __uint128_t uint128_t;
 #   else
 #       define HAVE_UINT128 0
 #   endif
 #endif
+
+#ifndef KEY128_T_DEFINED
+#define KEY128_T_DEFINED 1
+    typedef union {
+        unsigned char b[16];
+        #if HAVE_UINT128
+            uint128_t   u;
+        #endif
+    } key128_t;
+#endif
+
+typedef uint8_t  ind_t;
+typedef uint64_t state_t;
+typedef uint64_t vec_t;
+
+static INLINE vec_t C(vec_t row, ind_t j)
+{
+    return (row>>j)&1;
+}
 
 /*
  * set the default line length
@@ -73,7 +92,7 @@ static INLINE uint64_t ns_now_monotonic(void) {
     const clockid_t cid = CLOCK_MONOTONIC_RAW;
 #else
     const clockid_t cid = CLOCK_MONOTONIC;
-#endif    
+#endif
     if (clock_gettime(cid, &ts) != 0) {
             return 0;
     }
@@ -88,9 +107,6 @@ static INLINE float toc_sec(void)
     return toc()/1000000000.0;
 }
 
-extern unsigned int verbosity_level;
-
-#include <stdarg.h>
 void printlog(unsigned int v, const char *format, ...);
 
 void increase_verbosity(void);
@@ -99,5 +115,3 @@ static INLINE void remove_newline(char *s)
 {
     s[strcspn(s, "\r\n")] = 0;
 }
-
-#endif

--- a/configure
+++ b/configure
@@ -664,8 +664,6 @@ build
 OPENMP_CFLAGS
 XXHASH_LIBS
 XXHASH_CFLAGS
-GLIB_LIBS
-GLIB_CFLAGS
 NAUTY_LIBS
 NAUTY_CFLAGS
 RPATH
@@ -752,8 +750,6 @@ PKG_CONFIG_PATH
 PKG_CONFIG_LIBDIR
 NAUTY_CFLAGS
 NAUTY_LIBS
-GLIB_CFLAGS
-GLIB_LIBS
 XXHASH_CFLAGS
 XXHASH_LIBS'
 
@@ -1414,8 +1410,6 @@ Some influential environment variables:
   NAUTY_CFLAGS
               C compiler flags for NAUTY, overriding pkg-config
   NAUTY_LIBS  linker flags for NAUTY, overriding pkg-config
-  GLIB_CFLAGS C compiler flags for GLIB, overriding pkg-config
-  GLIB_LIBS   linker flags for GLIB, overriding pkg-config
   XXHASH_CFLAGS
               C compiler flags for XXHASH, overriding pkg-config
   XXHASH_LIBS linker flags for XXHASH, overriding pkg-config
@@ -4757,78 +4751,10 @@ printf "%s\n" "yes" >&6; }
 
 fi
 
-
-pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for glib-2.0 >= 2.32" >&5
-printf %s "checking for glib-2.0 >= 2.32... " >&6; }
-
-if test -n "$GLIB_CFLAGS"; then
-    pkg_cv_GLIB_CFLAGS="$GLIB_CFLAGS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"glib-2.0 >= 2.32\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "glib-2.0 >= 2.32") 2>&5
-  ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_GLIB_CFLAGS=`$PKG_CONFIG --cflags "glib-2.0 >= 2.32" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-if test -n "$GLIB_LIBS"; then
-    pkg_cv_GLIB_LIBS="$GLIB_LIBS"
- elif test -n "$PKG_CONFIG"; then
-    if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"glib-2.0 >= 2.32\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "glib-2.0 >= 2.32") 2>&5
-  ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; then
-  pkg_cv_GLIB_LIBS=`$PKG_CONFIG --libs "glib-2.0 >= 2.32" 2>/dev/null`
-		      test "x$?" != "x0" && pkg_failed=yes
-else
-  pkg_failed=yes
-fi
- else
-    pkg_failed=untried
-fi
-
-
-
-if test $pkg_failed = yes; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-
-if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
-        _pkg_short_errors_supported=yes
-else
-        _pkg_short_errors_supported=no
-fi
-        if test $_pkg_short_errors_supported = yes; then
-                GLIB_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "glib-2.0 >= 2.32" 2>&1`
-        else
-                GLIB_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "glib-2.0 >= 2.32" 2>&1`
-        fi
-        # Put the nasty error message in config.log where it belongs
-        echo "$GLIB_PKG_ERRORS" >&5
-
-        as_fn_error $? "GLib 2.32 or newer is required." "$LINENO" 5
-elif test $pkg_failed = untried; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-        as_fn_error $? "GLib 2.32 or newer is required." "$LINENO" 5
-else
-        GLIB_CFLAGS=$pkg_cv_GLIB_CFLAGS
-        GLIB_LIBS=$pkg_cv_GLIB_LIBS
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-
-
-fi
+#PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.32],
+#                  [AC_SUBST(GLIB_CFLAGS)]
+#                  [AC_SUBST(GLIB_LIBS)],
+#                  [AC_MSG_ERROR([GLib 2.32 or newer is required.])])
 
 
 pkg_failed=no

--- a/configure.ac
+++ b/configure.ac
@@ -66,11 +66,6 @@ PKG_CHECK_MODULES([NAUTY], [libnauty >= 2.9.1],
                   [AC_SUBST(NAUTY_LIBS)],
                   [AC_MSG_ERROR([nauty 2.9.1 or newer is required.])])
 
-PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.32],
-                  [AC_SUBST(GLIB_CFLAGS)]
-                  [AC_SUBST(GLIB_LIBS)],
-                  [AC_MSG_ERROR([GLib 2.32 or newer is required.])])
-
 PKG_CHECK_MODULES([XXHASH], [libxxhash >= 0.8.1],
                   [AC_SUBST(XXHASH_CFLAGS)]
                   [AC_SUBST(XXHASH_LIBS)],

--- a/dag.h
+++ b/dag.h
@@ -1,8 +1,9 @@
-#ifndef DAG_H
-#define DAG_H
+#pragma once
 
 #include <nauty.h>
 #include <gtools.h>
+#include <stdbool.h>
+
 #include "d6pack11.h"
 
 /**
@@ -23,7 +24,6 @@
 void init_nauty_data(int n);
 void free_nauty_data(void);
 
-#include "bott.h"
 /**
  * @brief Converts a binary matrix to a digraph6 (d6) string representation.
  *
@@ -65,7 +65,7 @@ char* matrix_to_d6(const vec_t *mat, int dim, char *dag_gcode);
 int matrix_from_d6(char *s, vec_t *mat, ind_t dim);
 /**
  * @brief Converts an adjacency matrix to its canonical digraph6 (d6) representation.
- * 
+ *
  * Converts a given adjacency matrix representation of a directed graph (DAG) into
  * D6 string representation of its canonical form.
  *
@@ -93,5 +93,3 @@ int matrix_from_graph(graph *g, vec_t *mat);
 int matrix_to_graph(graph *g, const vec_t *mat);
 
 graph *get_dag_g(void);
-
-#endif // DAG_H

--- a/gap.c
+++ b/gap.c
@@ -82,7 +82,7 @@ Obj BottPrint(Obj self)
     if (initialized()) {
         for (i=0; i<dim; i++) {
             for (j=0; j<dim; j++) {
-                printf("%c", c[C(mat[i],dim,j)]);
+                printf("%c", c[C(mat[i],j)]);
             }
             printf("\n");
         }
@@ -110,7 +110,7 @@ Obj PLIST_MAT(vec_t *mat, ind_t dim)
 
         for (j=0, k=0; k<len && j<dim; ) {
             // increment j after checking
-            if (C(mat[i],dim,j++)) {
+            if (C(mat[i],j++)) {
                 // if here, the j value is already incremented
                 SET_ELM_PLIST( row, ++k, INTOBJ_INT(j));
             }
@@ -151,7 +151,7 @@ Obj OBJ_MAT(vec_t *mat, ind_t dim)
         SET_LEN_PLIST(row, dim);
 
         for (j=0; j<dim; j++) {
-            SET_ELM_PLIST( row, j+1, INTOBJ_INT(C(mat[i],dim,j)));
+            SET_ELM_PLIST( row, j+1, INTOBJ_INT(C(mat[i],j)));
         }
         SET_ELM_PLIST(M, i+1, row );
         CHANGED_BAG(M);

--- a/mats.c
+++ b/mats.c
@@ -1,7 +1,7 @@
-#include "common.h"
+#include <omp.h>
+
 #include "bott.h"
 #include "dag.h"
-#include <omp.h>
 
 void help(const char *name)
 {

--- a/orientedf.c
+++ b/orientedf.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "bott.h"
 #include "dag.h"
 
 int main(void) {

--- a/parse_scaled.h
+++ b/parse_scaled.h
@@ -1,19 +1,13 @@
 #pragma once
+
 #include <ctype.h>
-#include <errno.h>
-#include <limits.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
 
 /* Parses decimal with optional suffix:
    - K/M/G/T/P/E   => *1000, *1000^2, ...
    - Ki/Mi/Gi/...  => *1024, *1024^2, ...
    Optional trailing 'B'/'b' is accepted (e.g., "2MiB").
    Returns true on success; false on invalid input or overflow. */
-static inline bool parse_scaled_size(const char *s, size_t *out)
+static INLINE bool parse_scaled_size(const char *s, size_t *out)
 {
     if (!s || !*s || !out) return false;
 
@@ -28,7 +22,7 @@ static inline bool parse_scaled_size(const char *s, size_t *out)
     unsigned long long mult = 1ULL;
 
     if (*end) {
-        char c1 = (char)toupper((unsigned char)*end);
+        char c1 = (char)toupper((unsigned char)*end); 
         char c2 = (char)toupper((unsigned char)*(end + 1));
         const char *p = end;
 
@@ -75,7 +69,7 @@ static inline bool parse_scaled_size(const char *s, size_t *out)
     }
 
     // Overflow‑safe multiply into size_t
-#if defined(__SIZEOF_INT128__)
+#if HAVE_UINT128
     __uint128_t prod = ((__uint128_t)base) * ((__uint128_t)mult);
     if (prod > ( __uint128_t)SIZE_MAX) return false;
     *out = (size_t)prod;

--- a/spincf.c
+++ b/spincf.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "bott.h"
 #include "dag.h"
 #include "adjpack11.h"
 

--- a/spinf.c
+++ b/spinf.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "dag.h"
 #include "bott.h"
 #include "adjpack11.h"

--- a/test-adjpack_from_matrix.c
+++ b/test-adjpack_from_matrix.c
@@ -1,10 +1,10 @@
-#include "common.h"
 #include "adjpack11.h"
 #include "bucket.h"
+#include "bott.h"
 
-static ADJPACK_INLINE void adjpack_from_matrix_legacy(const vec_t *mat, unsigned n, key128_t *out) {
+static INLINE void adjpack_from_matrix_legacy(const vec_t *mat, unsigned n, key128_t *out) {
     assert(n >= 1 && n <= 11);
-#if D6PACK_HAVE_UINT128
+#if HAVE_UINT128
 	out->u = 0;
     uint64_t row;
     for (unsigned i = 0; i < n; ++i) {
@@ -32,9 +32,9 @@ static ADJPACK_INLINE void adjpack_from_matrix_legacy(const vec_t *mat, unsigned
     adjpack_set_n(out, n);
 }
 
-static ADJPACK_INLINE void adjpack_from_matrix_native(const vec_t *mat, unsigned n, key128_t *out) {
+static INLINE void adjpack_from_matrix_native(const vec_t *mat, unsigned n, key128_t *out) {
     assert(n >= 1 && n <= 11);
-#if D6PACK_HAVE_UINT128
+#if HAVE_UINT128
     // __uint128_t row = 0;
     out->u = 0;
     unsigned j = 0;
@@ -63,17 +63,16 @@ static ADJPACK_INLINE void adjpack_from_matrix_native(const vec_t *mat, unsigned
 }
 
 bool test_correctness() {
-    // printf("Testing correctness of adjpack_from_matrix vs adjpack_from_matrix_legacy...\n");
 
     for (unsigned dim = 1; dim <= 11; ++dim) {
         vec_t *mat = init(dim);
         bool all_passed = true;
 
-        // Test dla kilku przykładowych macierzy
+        // Test for few example matrices
         for (unsigned i = 0; i < 100; ++i) {
             for (unsigned r = 0; r < dim; ++r) {
-                mat[r] = i ^ (r * 0xA5A5A5A5A5A5A5A5ULL); // przykładowe dane
-                mat[r] &= ((1ULL << dim) - 1); // ograniczenie do dim bitów
+                mat[r] = i ^ (r * 0xA5A5A5A5A5A5A5A5ULL); // example data
+                mat[r] &= ((1ULL << dim) - 1); // limit to dim bits
             }
 
             key128_t a, b;
@@ -109,7 +108,7 @@ void benchmark(bool verbose) {
     vec_t *mat = init(dim);
     volatile key128_t out;
 
-    // Wypełnij przykładową macierz
+    // fill matrix with some data
     for (unsigned r = 0; r < dim; ++r)
         mat[r] = (r * 0x123456789ABCDEFULL) & ((1ULL << dim) - 1);
 

--- a/test-bitreverse.c
+++ b/test-bitreverse.c
@@ -1,15 +1,16 @@
-#include "common.h"
-#include "adjpack11.h"
 #include <inttypes.h>
 
+#include "adjpack11.h"
+#include "bott.h"
+
 #if defined(__clang__) && __clang_major__ >= 5
-static ADJPACK_INLINE uint64_t bitreverse64_legacy(uint64_t x) {
+static INLINE uint64_t bitreverse64_legacy(uint64_t x) {
     // Check if the compiler supports a built-in function for bit reversal.
     // Clang supports this from version 5.
     return __builtin_bitreverse64(x);
 }
 #else
-static ADJPACK_INLINE uint64_t bitreverse64_legacy(uint64_t x) {
+static INLINE uint64_t bitreverse64_legacy(uint64_t x) {
     // Portable, and very efficient implementation as a fallback.
     x = ((x & 0x5555555555555555ULL) <<  1) | ((x >>  1) & 0x5555555555555555ULL);
     x = ((x & 0x3333333333333333ULL) <<  2) | ((x >>  2) & 0x3333333333333333ULL);
@@ -21,7 +22,7 @@ static ADJPACK_INLINE uint64_t bitreverse64_legacy(uint64_t x) {
 }
 #endif
 
-static ADJPACK_INLINE __uint128_t bitreverse128_native(__uint128_t x) {
+static INLINE __uint128_t bitreverse128_native(__uint128_t x) {
 #if defined(__clang__) && __clang_major__ >= 18
     return (((__uint128_t)__builtin_bitreverse64((uint64_t)x))<<64) | (__uint128_t)__builtin_bitreverse64((uint64_t)(x >> 64));
 #else
@@ -48,11 +49,11 @@ static ADJPACK_INLINE __uint128_t bitreverse128_native(__uint128_t x) {
 #endif
 }
 
-static ADJPACK_INLINE __uint128_t bitreverse128_legacy(__uint128_t x) {
+static INLINE __uint128_t bitreverse128_legacy(__uint128_t x) {
     // Portable, and very efficient implementation as a fallback.
     uint64_t hi = (uint64_t)(x >> 64);
     uint64_t lo = (uint64_t)x;
-    
+
     return bitreverse64(hi) | ((__uint128_t)bitreverse64(lo) << 64);
 }
 
@@ -134,7 +135,7 @@ void benchmark128() {
     volatile __uint128_t sum = 0;
     clock_t start, end;
 
-    // Rozgrzewka
+    // warm up
     for (int i = 0; i < N; ++i) {
         __uint128_t x = ((__uint128_t)i << 64) | (N - i);
         sum += bitreverse128_native(x);

--- a/test-bott-generate.c
+++ b/test-bott-generate.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "bott.h"
 #include "dag.h"
 #include "bucket.h"
@@ -13,7 +12,7 @@ int main(void)
 
     state_t max_state = get_max_state(dim);
 
-    GHashBucket *code_set = g_bucket_new_128(NULL, NULL, 1023);
+    GHashBucket *code_set = g_bucket_new_128(NULL, 1023);
 
     vec_t *mat = init(dim);
     key128_t k;

--- a/test-bott-populate_cache.c
+++ b/test-bott-populate_cache.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "bott.h"
 #include "dag.h"
 #include "bucket.h"
@@ -78,9 +77,8 @@ int main(void)
         0x22, //00100010
         0xe2, //11100010
         0x42, //01000010
-        0x82  //10000010 
+        0x82  //10000010
     };
-    
 
     vec_t *cache = NULL;
     size_t cache_size = 0;
@@ -99,6 +97,6 @@ int main(void)
     free(cache);
 
     printf("=== [bott-populate_cache] all tests passed ===\n");
-    
+
     return 0;
 }

--- a/test-bott-upper_triangular.c
+++ b/test-bott-upper_triangular.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "bott.h"
 #include "dag.h"
 

--- a/test-canon.c
+++ b/test-canon.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "dag.h"
 #include "adjpack11.h"
 #include "d6pack11.h"  // for d6pack_decode

--- a/test-mat-graph.c
+++ b/test-mat-graph.c
@@ -1,4 +1,3 @@
-#include "common.h"
 #include "dag.h"
 #include "adjpack11.h"
 #include "d6pack11.h"  // for d6pack_decode

--- a/test-matrix_from_d6.c
+++ b/test-matrix_from_d6.c
@@ -1,7 +1,6 @@
-#include "common.h"
 #include "dag.h"
 #include "adjpack11.h"
-#include "d6pack11.h"  // for d6pack_decode
+#include "d6pack11.h"
 
 void print_key_bits(const key128_t *k, const char *label) {
     printf("%s: ", label);
@@ -24,7 +23,7 @@ int matrix_from_d6_1(char *s, vec_t *mat, ind_t dim)
     }
 
     n = graphsize(s);
-    
+
     if (n <= 0 || n > dim) {
         return -1;
     }
@@ -33,12 +32,10 @@ int matrix_from_d6_1(char *s, vec_t *mat, ind_t dim)
 
     x = 0;
     p = s + 1 + SIZELEN(n);
-    // p = s + SIZELEN(n);
 
     k = 1;
     for (i = 0; i < n; ++i)
     {
-        // mat[i] = 0;
         for (j = 0; j < n; ++j)
         {
             if (--k == 0)
@@ -46,12 +43,7 @@ int matrix_from_d6_1(char *s, vec_t *mat, ind_t dim)
                 k = 6;
                 x = *(p++) - BIAS6;
             }
-            
-            // if ((x & TOPBIT6))
-            // {
-            //     mat[i] |= (1ULL << j);
-            // }
-            
+
             mat[i] |= (vec_t)((x & TOPBIT6)!=0) << j;
             x <<= 1;
         }
@@ -131,6 +123,6 @@ int main(void) {
     printf("    matrix_from_d6_1:  %.3f\n", t_matrix_from_d6_1/1e6);
     printf("    matrix_from_d6_2:  %.3f\n", t_matrix_from_d6_2/1e6);
     printf("=== [matrix_from_d6] all tests completed ===\n");
-   
+
     return 0;
 }

--- a/test-pack.c
+++ b/test-pack.c
@@ -1,7 +1,6 @@
-#include "common.h"
 #include "dag.h"
 #include "adjpack11.h"
-#include "d6pack11.h"  // for d6pack_decode
+#include "d6pack11.h"
 
 void print_key_bits(const key128_t *k, const char *label) {
     printf("%s: ", label);

--- a/tlsbuf.c
+++ b/tlsbuf.c
@@ -1,8 +1,6 @@
-#include "tlsbuf.h"
-
-#include <stdlib.h>
-#include <string.h>
 #include <omp.h>
+
+#include "tlsbuf.h"
 
 void buffer_init(OutputBuffer *buffer, size_t initial_capacity, FILE *out) {
     buffer->lines = malloc(initial_capacity * sizeof(char*));
@@ -58,10 +56,10 @@ void monitor_progress(unsigned long *progress_ptr, unsigned long total, FILE *st
     double now, pct, speed;
     char etabuf[256] = {0};
 
-    for (;;) {    
+    for (;;) {
         #pragma omp atomic read
             cur = *progress_ptr;
-        
+
         if (cur >= total) break;
 
         now = omp_get_wtime();

--- a/tlsbuf.h
+++ b/tlsbuf.h
@@ -1,5 +1,4 @@
-#ifndef TLSBUF_H
-#define TLSBUF_H
+#pragma once
 
 #include "common.h"
 
@@ -22,5 +21,3 @@ void buffer_add(OutputBuffer *buffer, char* line);
 void buffer_flush(OutputBuffer *buffer);
 
 void monitor_progress(unsigned long *progress_ptr, unsigned long total, FILE *stream);
-
-#endif /* TLSBUF_H */

--- a/uniqueg.c
+++ b/uniqueg.c
@@ -1,12 +1,10 @@
-#include "common.h"
+#include <omp.h>
+
 #include "dag.h"
 #include "bucket.h"
 #include "adjpack11.h"
 #include "parse_scaled.h"
-#include "common.h"
 #include "tlsbuf.h"
-
-#include <omp.h>
 
 void help(const char *progname) {
     if (progname == NULL) progname = "uniqueg";
@@ -32,10 +30,9 @@ int main(int argc, char *argv[]) {
     // always zero the timer at start of main
     tic();
     // default settings
-    size_t lines_capacity = 100000; 
+    size_t lines_capacity = 100000;
     int num_shards = 256;
     int num_threads = omp_get_max_threads(); // default max threads
-    int v = 0;
     bool canon = false;
 
     FILE *in = stdin, *out = stdout;
@@ -44,7 +41,7 @@ int main(int argc, char *argv[]) {
     while ((opt = getopt(argc, argv, "l:n:j:vi:o:c")) != -1) {
         switch (opt) {
         case 'v':
-            ++v;
+            increase_verbosity();
             break;
         case 'j':
             num_threads = (ind_t)atoi(optarg);
@@ -87,8 +84,6 @@ int main(int argc, char *argv[]) {
     }
 
     // variables
-    verbosity_level = v;
-
     size_t line_count = 0;
     char buffer[MAXLINE];
 
@@ -113,7 +108,7 @@ int main(int argc, char *argv[]) {
     assert(dim > 0 && dim <= 11);
 
     // Global dedup across orbits by CANONICAL key
-    GHashBucket *g_canonical_set =g_bucket_new_128(g_free, NULL, num_shards);
+    GHashBucket *g_canonical_set =g_bucket_new_128(free, num_shards);
 
     size_t batch_num = 0;
     size_t num_of_reps = 0;
@@ -157,7 +152,7 @@ int main(int argc, char *argv[]) {
                     buffer_add(&thread_buffer, line);
                 }
             }
-            
+
             #pragma omp atomic
                 num_of_reps += local_reps;
 

--- a/upperf.c
+++ b/upperf.c
@@ -1,4 +1,4 @@
-#include "common.h"
+#include "bott.h"
 #include "dag.h"
 
 int main(void) {

--- a/upperg.c
+++ b/upperg.c
@@ -1,51 +1,5 @@
-#include "common.h"
 #include "dag.h"
 
-// Topologiczne sortowanie (Kahn), działa dla grafów skierowanych zapisanych
-// w g (n wierzch., m = SETWORDSNEEDED(n)). Zwraca true dla DAG.
-// Wynikowa permutacja wierzchołków w tablicy 'order' (order[i] = oryginalny wierzchołek na miejscu i)
-/*
-static bool topo_sort(const graph *g, int n, int m, int *order)
-{
-    int *in_degree = (int*)calloc((size_t)n, sizeof(int));
-    int *q = (int*)malloc((size_t)n * sizeof(int));
-    if (!in_degree || !q) { free(in_degree); free(q); return false; }
-
-    // 1) stopnie wejściowe
-    for (int u = 0; u < n; ++u) {
-        set *row = GRAPHROW(g, u, m);
-        for (int v = 0; v < n; ++v) {
-            if (ISELEMENT(row, v)) {
-                ++in_degree[v];
-            }
-        }
-    }
-
-    // 2) kolejka wierzchołków o stopniu 0
-    int head = 0, tail = 0;
-    for (int v = 0; v < n; ++v) {
-        if (in_degree[v] == 0) q[tail++] = v;
-    }
-
-    // 3) przetwarzanie
-    int outc = 0;
-    while (head < tail) {
-        int u = q[head++];
-        order[outc++] = u;
-
-        set *row = GRAPHROW(g, u, m);
-        for (int v = 0; v < n; ++v) {
-            if (ISELEMENT(row, v)) {
-                if (--in_degree[v] == 0) q[tail++] = v;
-            }
-        }
-    }
-
-    free(in_degree);
-    free(q);
-    return outc == n;
-}
-*/
 int main(void)
 {
     int   n;
@@ -71,7 +25,7 @@ int main(void)
         }
         printf("%s\n", d6);
     } while (fgets(s, sizeof(s), stdin) != NULL);
-    
+
     free_nauty_data();
 
     return 0;


### PR DESCRIPTION
- Removed unnecessary includes and comments in various files.
- Updated static inline functions to use INLINE macro for consistency.
- Improved compile-time checks for type sizes in dag.c.
- Simplified matrix manipulation functions in dag.c and related files.
- Enhanced parallel processing in uniqueg.c and orbitg.c.
- Streamlined memory management and error handling in multiple files.
- Updated verbosity handling in command-line options across several files.
- Cleaned up whitespace and formatting for better readability.
- Ensured consistent use of `free` instead of `g_free` where applicable.